### PR TITLE
Add portfolio management

### DIFF
--- a/crypto-analyst-bot/database/models.py
+++ b/crypto-analyst-bot/database/models.py
@@ -48,6 +48,7 @@ class TrackedCoin(Base):
     user_id = Column(BigInteger, ForeignKey('users.id'), nullable=False, index=True)
     coin_symbol = Column(String, nullable=False, index=True)
     quantity = Column(Float, nullable=True, default=0.0)
+    buy_price = Column(Float, nullable=True, default=0.0, comment="Цена покупки за единицу")
     added_at = Column(DateTime(timezone=True), server_default=func.now())
     user = relationship("User", back_populates="tracked_coins")
 


### PR DESCRIPTION
## Summary
- add `buy_price` to `TrackedCoin`
- implement portfolio CRUD operations
- handle `/portfolio add` and `/portfolio remove`
- compute current balance with profit/loss

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68829eecf2188325ace98eefde78a3b9