### PR TITLE
Add education module

### DIFF
--- a/crypto-analyst-bot/bot/core.py
+++ b/crypto-analyst-bot/bot/core.py
@@ -79,7 +79,34 @@ async def handle_premarket_scan(update: Update, context: CallbackContext, payloa
         text=response,
     )
 async def handle_edu_lesson(update: Update, context: CallbackContext, payload: str, db_session: AsyncSession):
-    await update.effective_message.reply_text(f"⏳ Готовлю урок по теме *'{payload}'*...", parse_mode=constants.ParseMode.MARKDOWN)
+    """Отправляет краткое определение крипто-термина и предлагает мини‑курсы."""
+    if not update.effective_message:
+        return
+
+    from education import get_definition, list_courses
+
+    term_definition = get_definition(payload)
+
+    if term_definition:
+        response = f"📚 *{payload.upper()}* — {term_definition}"
+    else:
+        response = (
+            f"😕 Урок по теме *{payload}* пока не готов. "
+            "В будущем здесь появятся расширенные материалы."
+        )
+
+    await update.effective_message.reply_text(
+        response, parse_mode=constants.ParseMode.MARKDOWN
+    )
+
+    # Небольшое предложение о дополнительных курсах
+    courses = list_courses()
+    if courses:
+        course_lines = [f"• {c.title} — {c.stars_price}⭐" for c in courses]
+        offer = "\n\nДоступны мини‑курсы (оплата звёздами):\n" + "\n".join(course_lines)
+        await update.effective_message.reply_text(
+            offer, parse_mode=constants.ParseMode.MARKDOWN
+        )
 async def handle_track_coin(update: Update, context: CallbackContext, payload: str, db_session: AsyncSession):
     if not payload:
         await update.effective_message.reply_text("Укажите символ монеты.")

--- a/crypto-analyst-bot/education.py
+++ b/crypto-analyst-bot/education.py
@@ -1,0 +1,51 @@
+"""education.py
+Модуль с краткими пояснениями терминов и набросками для будущих обучающих курсов.
+"""
+
+from typing import Dict, Optional
+
+# Небольшой словарь терминов. В дальнейшем данные будут загружаться администратором
+# через бота или из базы данных.
+TERMS: Dict[str, str] = {
+    "DEFI": "DeFi (Decentralized Finance) — экосистема финансовых сервисов на базе блокчейна без посредников.",
+    "DAO": "DAO (Decentralized Autonomous Organization) — децентрализованная автономная организация, управляемая участниками через смарт‑контракты.",
+    "NFT": "NFT (Non‑Fungible Token) — уникальный токен, подтверждающий право собственности на цифровой объект.",
+    "DEX": "DEX (Decentralized Exchange) — децентрализованная биржа для обмена криптоактивов напрямую между пользователями.",
+}
+
+
+def get_definition(term: str) -> Optional[str]:
+    """Возвращает краткое объяснение термина."""
+    return TERMS.get(term.upper())
+
+
+# ---- Заготовки для расширенного обучения ----
+class CourseInfo:
+    """Модель данных для будущих мини‑курсов."""
+
+    def __init__(self, course_id: str, title: str, stars_price: int):
+        self.course_id = course_id
+        self.title = title
+        self.stars_price = stars_price
+        # В дальнейшем здесь будут поля с описанием и ссылкой на файл или видео
+
+
+# Демонстрационный список курсов. В будущем данные будут браться из БД
+# или загружаться администратором через панель бота.
+DEMO_COURSES = [
+    CourseInfo(course_id="defi101", title="DeFi за 30 минут", stars_price=50),
+    CourseInfo(course_id="dao-guide", title="Как устроены DAO", stars_price=40),
+]
+
+
+def list_courses() -> list[CourseInfo]:
+    """Возвращает список доступных мини‑курсов."""
+    return DEMO_COURSES
+
+
+def get_course(course_id: str) -> Optional[CourseInfo]:
+    """Возвращает информацию о курсе по идентификатору."""
+    for course in DEMO_COURSES:
+        if course.course_id == course_id:
+            return course
+    return None


### PR DESCRIPTION
## Summary
- implement `education.py` with short definitions for common crypto terms
- add placeholders for future mini-courses
- enhance `handle_edu_lesson` to show definitions and offer courses

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882a258f8d08325a260b71e837c59b0