### PR TITLE
Add optional GPT-4o mini support with caching

### DIFF
--- a/crypto-analyst-bot/requirements.txt
+++ b/crypto-analyst-bot/requirements.txt
@@ -22,3 +22,4 @@ apscheduler
 # --- Веб-скрейпинг (опционально) ---
 beautifulsoup4
 requests
+openai


### PR DESCRIPTION
## Summary
- enable GPT-4o access via OpenAI API
- refine the analysis prompt
- implement small in-memory cache for analysis replies
- add new `openai` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a5dd658c8325b9e4161bbbabe196