### PR TITLE
Enhance user analytics

### DIFF
--- a/crypto-analyst-bot/analysis/handler.py
+++ b/crypto-analyst-bot/analysis/handler.py
@@ -157,6 +157,7 @@ async def handle_token_analysis(update: Update, context: CallbackContext, payloa
     if not update.effective_message:
         return
     user_id = update.effective_user.id
+    await db_ops.increment_request_counter(db_session, user_id, "analysis_requests")
     lang = context.user_data.get('lang', 'ru')
 
     if not payload:

--- a/crypto-analyst-bot/bot/core.py
+++ b/crypto-analyst-bot/bot/core.py
@@ -162,6 +162,8 @@ async def handle_edu_lesson(update: Update, context: CallbackContext, payload: s
 
     from education import get_definition, list_courses
 
+    await db_ops.increment_request_counter(db_session, update.effective_user.id, "lesson_requests")
+
     lang = context.user_data.get('lang', 'ru')
     term_definition = get_definition(payload)
 

--- a/crypto-analyst-bot/crypto/handler.py
+++ b/crypto-analyst-bot/crypto/handler.py
@@ -51,8 +51,9 @@ async def handle_crypto_info_request(update: Update, context: CallbackContext, p
     Обрабатывает запрос на получение информации о криптовалюте.
     """
     if not update.effective_message: return
-    
+
     user_id = update.effective_user.id
+    await db_ops.increment_request_counter(db_session, user_id, "price_requests")
     lang = context.user_data.get('lang', 'ru')
     symbols = payload.split(',')
     coin_ids, not_found = await get_coin_ids_from_symbols(symbols)

--- a/crypto-analyst-bot/database/models.py
+++ b/crypto-analyst-bot/database/models.py
@@ -24,6 +24,13 @@ class User(Base):
     timezone = Column(String, nullable=False, default="UTC")
     currency = Column(String, nullable=False, default="USD")
     stars_balance = Column(Integer, nullable=False, default=0, comment="Баланс звёзд для платных функций")
+
+    # --- Метрики активности ---
+    price_requests = Column(Integer, nullable=False, default=0)
+    analysis_requests = Column(Integer, nullable=False, default=0)
+    lesson_requests = Column(Integer, nullable=False, default=0)
+    stars_spent = Column(Integer, nullable=False, default=0)
+    last_contact_at = Column(DateTime(timezone=True), nullable=True)
     
     alerts = relationship("PriceAlert", back_populates="user", cascade="all, delete-orphan")
     tracked_coins = relationship("TrackedCoin", back_populates="user", cascade="all, delete-orphan")


### PR DESCRIPTION
## Summary
- extend `User` model with request counters and star spend tracking
- update database operations for new metrics
- track requests from handlers for prices, analysis and lessons
- keep last contact timestamp in chat history

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883606e5d308325ab57d5b1c045147b