### PR TITLE
Add basic admin API

### DIFF
--- a/crypto-analyst-bot/admin/routes.py
+++ b/crypto-analyst-bot/admin/routes.py
@@ -1,0 +1,101 @@
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+import secrets, os
+from typing import Optional
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.engine import get_db_session
+from database import operations as db_ops
+from database.models import Purchase
+from sqlalchemy.future import select
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+security = HTTPBasic()
+
+def verify_credentials(credentials: HTTPBasicCredentials = Depends(security)):
+    username = os.getenv("ADMIN_USER", "admin")
+    password = os.getenv("ADMIN_PASS", "admin")
+    correct_username = secrets.compare_digest(credentials.username, username)
+    correct_password = secrets.compare_digest(credentials.password, password)
+    if not (correct_username and correct_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return True
+
+# --- User management ---
+@router.get("/users/{user_id}")
+async def get_user_details(user_id: int, authorized: bool = Depends(verify_credentials), db: AsyncSession = Depends(get_db_session)):
+    user = await db_ops.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    stats = await db_ops.get_user_stats(db, user_id)
+    sub = await db_ops.get_subscription(db, user_id)
+    result = await db.execute(select(Purchase).filter(Purchase.user_id == user_id))
+    purchases = [p.product_id for p in result.scalars().all()]
+    return {
+        "id": user.id,
+        "username": user.username,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "stars_balance": user.stars_balance,
+        "subscription_active": sub.is_active if sub else False,
+        "stats": stats,
+        "purchases": purchases,
+    }
+
+@router.post("/users/{user_id}/subscription")
+async def set_subscription(user_id: int, active: bool, authorized: bool = Depends(verify_credentials), db: AsyncSession = Depends(get_db_session)):
+    sub = await db_ops.create_or_update_subscription(db, user_id, is_active=active)
+    return {"user_id": user_id, "active": sub.is_active}
+
+# --- Products management ---
+@router.post("/products")
+async def create_product(
+    name: str,
+    description: str,
+    stars_price: int,
+    item_type: str,
+    file: UploadFile = File(...),
+    authorized: bool = Depends(verify_credentials),
+    db: AsyncSession = Depends(get_db_session),
+):
+    content_path = os.path.join("uploads", file.filename)
+    os.makedirs("uploads", exist_ok=True)
+    with open(content_path, "wb") as f:
+        f.write(await file.read())
+    product = await db_ops.create_product(
+        db,
+        name=name,
+        description=description,
+        item_type=item_type,
+        stars_price=stars_price,
+        content_type="file",
+        content_value=content_path,
+    )
+    return {"id": product.id}
+
+
+# --- Courses management ---
+@router.post("/courses")
+async def create_course(
+    title: str,
+    description: str,
+    stars_price: int,
+    content_type: str,
+    file_id: Optional[str] = None,
+    authorized: bool = Depends(verify_credentials),
+    db: AsyncSession = Depends(get_db_session),
+):
+    course = await db_ops.create_course(
+        db,
+        title=title,
+        description=description,
+        stars_price=stars_price,
+        content_type=content_type,
+        file_id=file_id,
+    )
+    return {"id": course.id}

--- a/crypto-analyst-bot/database/operations.py
+++ b/crypto-analyst-bot/database/operations.py
@@ -331,6 +331,44 @@ async def get_product(session: AsyncSession, product_id: int):
     result = await session.execute(select(Product).filter(Product.id == product_id))
     return result.scalar_one_or_none()
 
+async def create_product(
+    session: AsyncSession,
+    name: str,
+    description: str,
+    item_type: str,
+    stars_price: int,
+    content_type: str,
+    content_value: str,
+    rating: int = 0,
+    is_active: bool = True,
+) -> Product:
+    product = Product(
+        name=name,
+        description=description,
+        rating=rating,
+        item_type=item_type,
+        stars_price=stars_price,
+        content_type=content_type,
+        content_value=content_value,
+        is_active=is_active,
+    )
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+    return product
+
+async def update_product(session: AsyncSession, product_id: int, **kwargs) -> None:
+    if not kwargs:
+        return
+    await session.execute(
+        sqlalchemy_update(Product).where(Product.id == product_id).values(**kwargs)
+    )
+    await session.commit()
+
+async def delete_product(session: AsyncSession, product_id: int) -> None:
+    await session.execute(sqlalchemy_delete(Product).where(Product.id == product_id))
+    await session.commit()
+
 async def add_purchase(session: AsyncSession, user_id: int, product_id: int):
     purchase = Purchase(user_id=user_id, product_id=product_id)
     session.add(purchase)
@@ -386,6 +424,40 @@ async def list_courses(session: AsyncSession):
 async def get_course(session: AsyncSession, course_id: int):
     result = await session.execute(select(Course).filter(Course.id == course_id))
     return result.scalar_one_or_none()
+
+async def create_course(
+    session: AsyncSession,
+    title: str,
+    description: str,
+    stars_price: int,
+    content_type: str,
+    file_id: Optional[str] = None,
+    is_active: bool = True,
+) -> Course:
+    course = Course(
+        title=title,
+        description=description,
+        stars_price=stars_price,
+        content_type=content_type,
+        file_id=file_id,
+        is_active=is_active,
+    )
+    session.add(course)
+    await session.commit()
+    await session.refresh(course)
+    return course
+
+async def update_course(session: AsyncSession, course_id: int, **kwargs) -> None:
+    if not kwargs:
+        return
+    await session.execute(
+        sqlalchemy_update(Course).where(Course.id == course_id).values(**kwargs)
+    )
+    await session.commit()
+
+async def delete_course(session: AsyncSession, course_id: int) -> None:
+    await session.execute(sqlalchemy_delete(Course).where(Course.id == course_id))
+    await session.commit()
 
 
 async def add_course_purchase(session: AsyncSession, user_id: int, course_id: int):

--- a/crypto-analyst-bot/main.py
+++ b/crypto-analyst-bot/main.py
@@ -39,9 +39,11 @@ from bot.core import handle_update
 from database.engine import init_db, get_db_session
 from background.scheduler import start_scheduler
 from analysis.metrics import gather_metrics
+from admin.routes import router as admin_router
 
 # --- Инициализация FastAPI ---
 app = FastAPI(title="Crypto AI Analyst Bot", version="1.0.0")
+app.include_router(admin_router)
 
 # --- Инициализация Telegram Bot API ---
 application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()


### PR DESCRIPTION
## Summary
- create `/admin` routes with basic auth
- implement endpoints for user info, subscription management and product/course creation
- expose admin router in `main.py`
- add CRUD helpers for products and courses

## Testing
- `python -m py_compile admin/routes.py database/operations.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68836b97169c8325ac85115bac1308a7