### PR TITLE
Add env example for bot setup

### DIFF
--- a/crypto-analyst-bot/.env.example
+++ b/crypto-analyst-bot/.env.example
@@ -1,0 +1,27 @@
+# Example environment configuration for Crypto Analyst Bot
+# Rename this file to .env and fill in the values before running the bot.
+
+# --- Core settings ---
+TELEGRAM_BOT_TOKEN=
+WEBHOOK_URL=
+DATABASE_URL=
+
+# --- Admin credentials ---
+ADMIN_USER=admin
+ADMIN_PASS=admin
+ADMIN_TELEGRAM_ID=
+PRIVATE_CHANNEL_ID=
+SUBSCRIPTION_LINK=
+
+# --- API keys (optional) ---
+COINGECKO_API_KEY=
+COINMARKETCAP_API_KEY=
+COINMARKETCAL_API_KEY=
+CRYPTORANK_API_KEY=
+CRYPTOPANIC_API_KEY=
+GEMINI_API_KEY=
+OPENAI_API_KEY=
+OPENAI_GPT_MODEL=gpt-4o
+
+# --- Redis cache ---
+REDIS_URL=redis://localhost:6379/0


### PR DESCRIPTION
## Summary
- provide `.env.example` listing required environment variables for the bot

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883aa440330832593d80c37bf114f5c