### PR TITLE
Fix language and intent classifier

### DIFF
--- a/crypto-analyst-bot/ai/dispatcher.py
+++ b/crypto-analyst-bot/ai/dispatcher.py
@@ -89,7 +89,10 @@ EXTRACT_ENTITIES_PROMPT = """
 
 async def classify_intent(user_input: str) -> str:
     """Шаг 1: Определяет только тип намерения."""
-    prompt = CLASSIFY_INTENT_PROMPT.format(user_input=user_input)
+    prompt = CLASSIFY_INTENT_PROMPT.format(
+        user_input=user_input,
+        INTENT_LIST_TEXT=INTENT_LIST_TEXT,
+    )
 
     if GEMINI_API_KEY:
         try:

--- a/crypto-analyst-bot/bot/core.py
+++ b/crypto-analyst-bot/bot/core.py
@@ -563,6 +563,7 @@ async def handle_portfolio_summary(update: Update, context: CallbackContext, pay
         return
 
     user_id = update.effective_user.id
+    lang = context.user_data.get('lang', 'ru')
     parts = payload.split()
     action = parts[0].lower() if parts else "list"
 


### PR DESCRIPTION
## Summary
- pass missing `INTENT_LIST_TEXT` when building the prompt
- initialise `lang` in `handle_portfolio_summary`

## Testing
- `PYTHONPATH=crypto-analyst-bot pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6883c2fb67248325a729db19e61161df