### PR TITLE
Enable search with DuckDuckGo helper

### DIFF
--- a/crypto-analyst-bot/analysis/handler.py
+++ b/crypto-analyst-bot/analysis/handler.py
@@ -19,6 +19,7 @@ from database import operations as db_ops
 from settings.messages import get_text
 from utils.api_clients import coingecko_client
 from utils import news_api
+from utils import google_search
 
 logger = logging.getLogger(__name__)
 load_dotenv()

--- a/crypto-analyst-bot/requirements.txt
+++ b/crypto-analyst-bot/requirements.txt
@@ -25,3 +25,4 @@ requests
 openai
 matplotlib
 redis>=4.6.0
+duckduckgo-search

--- a/crypto-analyst-bot/utils/google_search.py
+++ b/crypto-analyst-bot/utils/google_search.py
@@ -1,0 +1,25 @@
+import logging
+from types import SimpleNamespace
+from typing import List, Dict
+
+from duckduckgo_search import DDGS
+
+logger = logging.getLogger(__name__)
+
+def search(queries: List[str], max_results: int = 5) -> List[SimpleNamespace]:
+    """Return search results for each query using DuckDuckGo."""
+    ddgs = DDGS()
+    results_list = []
+    for q in queries:
+        results: List[Dict[str, str]] = []
+        try:
+            for r in ddgs.text(q, max_results=max_results):
+                results.append({
+                    "title": r.get("title"),
+                    "url": r.get("href"),
+                    "snippet": r.get("body", ""),
+                })
+        except Exception as e:
+            logger.error(f"Search error for '{q}': {e}")
+        results_list.append(SimpleNamespace(results=results))
+    return results_list


### PR DESCRIPTION
## Summary
- implement a small search helper using `duckduckgo_search`
- import it inside `analysis/handler.py`
- document new dependency

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d5b718088325a318d56449427bef