### PR TITLE
Fix zapysk startup commands

### DIFF
--- a/crypto-analyst-bot/zapysk.txt
+++ b/crypto-analyst-bot/zapysk.txt
@@ -1,3 +1,3 @@
-ngrok http 8000 
+ngrok http 8000
 
 uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- update `zapysk.txt` to only hold the intended startup commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6883d5bc39ec8325b72583cbfdd19ed3