### PR TITLE
Fix subscription scheduler and cleanup temp files

### DIFF
--- a/crypto-analyst-bot/bot/core.py
+++ b/crypto-analyst-bot/bot/core.py
@@ -665,7 +665,13 @@ async def handle_portfolio_summary(update: Update, context: CallbackContext, pay
                 chart_path = await create_price_chart(coin.coin_symbol)
                 if chart_path:
                     with open(chart_path, "rb") as img:
-                        await context.bot.send_photo(chat_id=update.effective_chat.id, photo=img)
+                        await context.bot.send_photo(
+                            chat_id=update.effective_chat.id, photo=img
+                        )
+                    try:
+                        os.remove(chart_path)
+                    except OSError:
+                        pass
             response = get_text(lang, 'portfolio_chart_sent')
 
     else:


### PR DESCRIPTION
## Summary
- clean up generated chart, PDF and markdown files after token analysis
- remove portfolio chart images after sending

## Testing
- `PYTHONPATH=crypto-analyst-bot pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e1e3122c832585aced6e3accd753