### PR TITLE
Fix missing imports in core

### DIFF
--- a/crypto-analyst-bot/bot/core.py
+++ b/crypto-analyst-bot/bot/core.py
@@ -21,7 +21,11 @@ from utils.validators import is_valid_id, is_valid_symbol
 # --- Импорт всех модулей проекта ---
 from ai.dispatcher import classify_intent, extract_entities
 from database import operations as db_ops
-from crypto.handler import handle_crypto_info_request
+from crypto.handler import (
+    handle_crypto_info_request,
+    COIN_ID_MAP,
+    get_coin_ids_from_symbols,
+)
 from settings.user import (
     handle_setup_alert,
     handle_manage_alerts,


### PR DESCRIPTION
## Summary
- add missing crypto utilities imports to bot core

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ef3d1794832594efc97925946fbb