### PR TITLE
Allow redirects in news API

### DIFF
--- a/crypto-analyst-bot/utils/news_api.py
+++ b/crypto-analyst-bot/utils/news_api.py
@@ -31,7 +31,7 @@ async def _fetch_cryptopanic(symbol: str, limit: int = 5) -> List[Dict]:
     url = "https://cryptopanic.com/api/v1/posts/"
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(url, params=params)
+            resp = await client.get(url, params=params, follow_redirects=True)
             resp.raise_for_status()
             data = resp.json()
     except Exception as e:
@@ -57,7 +57,7 @@ async def _fetch_coindesk(symbol: str, limit: int = 5) -> List[Dict]:
         return json.loads(cached)
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(url)
+            resp = await client.get(url, follow_redirects=True)
             resp.raise_for_status()
             text = resp.text
     except Exception as e:


### PR DESCRIPTION
## Summary
- allow redirects when fetching CryptoPanic API and CoinDesk RSS feeds

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f105ef488325a3fe799835ee8981