### PR TITLE
Fix CryptoPanic endpoint and note API key usage

### DIFF
--- a/crypto-analyst-bot/README.md
+++ b/crypto-analyst-bot/README.md
@@ -7,3 +7,12 @@ handlers.  All intents used by the AI classifier are stored in
 `config/intents.json` and routed via a simple `IntentRouter`.
 
 See [COMMANDS.md](COMMANDS.md) for the full list of available commands.
+
+## API keys
+
+Several features rely on external APIs. Create a `.env` file or set the
+following environment variables:
+
+- `CRYPTOPANIC_API_KEY` – access to CryptoPanic news
+- `COINMARKETCAP_API_KEY` – required for CoinMarketCap endpoints and sent
+  as `X-CMC_PRO_API_KEY` header

--- a/crypto-analyst-bot/utils/news_api.py
+++ b/crypto-analyst-bot/utils/news_api.py
@@ -28,7 +28,7 @@ async def _fetch_cryptopanic(symbol: str, limit: int = 5) -> List[Dict]:
     cached = await get_cache(cache_key)
     if cached:
         return json.loads(cached)
-    url = "https://cryptopanic.com/api/v1/posts/"
+    url = "https://cryptopanic.com/api/developer/v2/posts/"
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.get(url, params=params, follow_redirects=True)


### PR DESCRIPTION
## Summary
- update CryptoPanic URL to /api/developer/v2/posts/
- document API keys required for CryptoPanic and CoinMarketCap

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a0bc876083259d57e559e41bd669