### PR TITLE
Improve webhook exception handling

### DIFF
--- a/crypto-analyst-bot/main.py
+++ b/crypto-analyst-bot/main.py
@@ -170,7 +170,8 @@ async def telegram_webhook(
         return Response(status_code=403)
 
     try:
-        update_data = await request.json()
+        raw_body = await request.body()
+        update_data = json.loads(raw_body.decode("utf-8"))
 
         update_preview = Update.de_json(update_data, bot)
         if (
@@ -199,9 +200,9 @@ async def telegram_webhook(
             "Клиент (Telegram) отключился до того, как мы успели прочитать запрос. Игнорируем."
         )
     except json.JSONDecodeError:
-        logger.warning("Получен запрос с невалидным JSON. Игнорируем.")
+        logger.warning(f"Получен запрос с невалидным JSON: {raw_body!r}")
     except Exception as e:
-        logger.error(f"Неизвестная ошибка при обработке вебхука: {e}", exc_info=True)
+        logger.error(f"Ошибка при разборе обновления: {e!r}", exc_info=True)
 
     return Response(status_code=200)
 


### PR DESCRIPTION
## Summary
- more robust webhook JSON parsing using `await request.body()`
- log invalid bodies when JSON parsing fails
- clarify error logging when updates can't be parsed

## Testing
- `PYTHONPATH=crypto-analyst-bot pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e364ac308325974b439b1f62831e