### PR TITLE
Improve JSON error logging

### DIFF
--- a/crypto-analyst-bot/main.py
+++ b/crypto-analyst-bot/main.py
@@ -199,8 +199,13 @@ async def telegram_webhook(
         logger.warning(
             "Клиент (Telegram) отключился до того, как мы успели прочитать запрос. Игнорируем."
         )
-    except json.JSONDecodeError:
-        logger.warning(f"Получен запрос с невалидным JSON: {raw_body!r}")
+    except json.JSONDecodeError as e:
+        logger.warning(
+            "Получен запрос с невалидным JSON: %r, длина=%d, ошибка=%s",
+            raw_body,
+            len(raw_body),
+            e,
+        )
     except Exception as e:
         logger.error(f"Ошибка при разборе обновления: {e!r}", exc_info=True)
 


### PR DESCRIPTION
## Summary
- log the raw body length and error text when JSON decoding fails

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e88676008325acb0ff2e9fe5ea5e