### PR TITLE
Fix json name error in pre_market

### DIFF
--- a/crypto-analyst-bot/crypto/pre_market.py
+++ b/crypto-analyst-bot/crypto/pre_market.py
@@ -7,6 +7,7 @@ import os
 import logging
 from typing import List, Dict, Optional
 import asyncio
+import json
 from dotenv import load_dotenv
 import httpx
 from bs4 import BeautifulSoup


### PR DESCRIPTION
## Summary
- import `json` in `crypto/pre_market.py`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ef16b00c8325a1f97844ec36e8a7