### PR TITLE
Add env var docs

### DIFF
--- a/crypto-analyst-bot/.env.example
+++ b/crypto-analyst-bot/.env.example
@@ -1,1 +1,32 @@
+# Telegram bot configuration
+TELEGRAM_BOT_TOKEN=your-telegram-token              # Bot token from BotFather
+WEBHOOK_URL=https://your.domain/webhook             # Public URL for webhook
+PRIVATE_CHANNEL_ID=                                # Optional private channel ID
+ADMIN_TELEGRAM_ID=                                 # Telegram user ID of admin
+
+# Admin panel credentials
+ADMIN_USER=admin                                   # Username for /admin routes
+ADMIN_PASS=change-me                               # Password for /admin routes
+
+# Database and cache
 DATABASE_URL=postgresql+asyncpg://user:password@your-db-host:5432/dbname
+REDIS_URL=redis://localhost:6379/0                  # Redis connection string
+
+# AI models
+OPENAI_API_KEY=                                    # OpenAI API key
+OPENAI_GPT_MODEL=gpt-4o-mini                       # GPT model name
+GEMINI_API_KEY=                                    # Google Gemini API key
+
+# External crypto APIs
+COINGECKO_API_KEY=                                 # Coingecko data
+COINMARKETCAP_API_KEY=                             # CoinMarketCap data
+CRYPTOPANIC_API_KEY=                               # CryptoPanic news
+COINMARKETCAL_API_KEY=                             # CoinMarketCal events
+CRYPTORANK_API_KEY=                                # CryptoRank metrics
+
+# Subscription settings
+SUBSCRIPTION_PRICE=20                              # Monthly price in USD
+SUBSCRIPTION_DESC=Channel subscription             # Payment description
+
+# Optional user restriction
+ADMIN_ID=                                          # Telegram user allowed for some commands

--- a/crypto-analyst-bot/README.md
+++ b/crypto-analyst-bot/README.md
@@ -10,8 +10,9 @@ See [COMMANDS.md](COMMANDS.md) for the full list of available commands.
 
 ## API keys
 
-Several features rely on external APIs. Create a `.env` file or set the
-following environment variables:
+Several features rely on external APIs and bot configuration provided via
+environment variables. Copy `.env.example` to `.env` and fill in the values for
+your deployment. The most important variables are:
 
 - `CRYPTOPANIC_API_KEY` – access to CryptoPanic news
 - `COINMARKETCAP_API_KEY` – required for CoinMarketCap endpoints and sent


### PR DESCRIPTION
## Summary
- document all environment variables in `.env.example`
- instruct to copy `.env.example` in the README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884efb2033483258d7d67dd3c8e1b11