### PR TITLE
Improve JSON recovery and handle malformed commas

### DIFF
--- a/crypto-analyst-bot/tests/test_telegram_webhook.py
+++ b/crypto-analyst-bot/tests/test_telegram_webhook.py
@@ -244,9 +244,9 @@ def test_telegram_webhook_double_comma(monkeypatch):
         "effective_chat": {"id": 1},
         "effective_user": {"id": 2},
     }
-    # introduce a double comma inside JSON
+    # introduce a true double comma inside JSON
     text = json.dumps(update)
-    broken = text.replace('"hi"', '"hi",')
+    broken = text.replace('"hi"', '"hi",,')
     req = _make_request(broken.encode("utf-8"))
 
     called = {}


### PR DESCRIPTION
## Summary
- handle double commas when loading update JSON
- extend tests for malformed JSON with duplicate commas

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688505670a54832590456cab7aad80e9