### PR TITLE
Mask httpx request logs

### DIFF
--- a/crypto-analyst-bot/main.py
+++ b/crypto-analyst-bot/main.py
@@ -22,6 +22,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Silence verbose logs from the httpx library to avoid leaking sensitive
+# information such as the bot token in request URLs.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
 # --- Загрузка переменных окружения ---
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- silence httpx logger so request URLs don't expose the bot token

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688505670a54832590456cab7aad80e9